### PR TITLE
Tutorial[6]: Use type safe props with react components

### DIFF
--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -9,7 +9,7 @@ class App extends React.Component<any, any> {
     return (
       <div className="catch-of-the-day">
         <div className="menu">
-          <Header />
+          <Header tagline="Fresh Seafood Market" />
         </div>
         <Order />
         <Inventory />
@@ -46,7 +46,17 @@ class Inventory extends React.Component<any, any> {
 class Header extends React.Component<any, any> {
   render() {
     return (
-      <p>Header</p>
+      <header className="top">
+        <h1>
+          Catch
+          <span className="ofThe">
+            <span className="of">of</span>
+            <span className="the">the</span>
+          </span>
+          Day
+        </h1>
+        <h3 className="tagline"><span>{this.props.tagline}</span></h3>
+      </header>
     )
   }
 }

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -2,6 +2,13 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 /**
+ * Interfaces
+ */
+interface HeaderProps {
+  tagline: string
+}
+
+/**
  * App container
  */
 class App extends React.Component<any, any> {
@@ -43,7 +50,7 @@ class Inventory extends React.Component<any, any> {
 /**
  * Header Component
  */
-class Header extends React.Component<any, any> {
+class Header extends React.Component<HeaderProps, any> {
   render() {
     return (
       <header className="top">


### PR DESCRIPTION
**Prev** #4 
- [x] Header component refactored to use props
- [x] Header component uses header properties interface for type safety

Smaller PR that mainly focuses on using props to add variability to a react component. Taking this one step further, I added an interface for the Header properties to act as a type safe catch. See the error below for type safety in action. :tada: 

![headerprops](https://cloud.githubusercontent.com/assets/1335972/11455037/fcf70f50-95fc-11e5-8df1-09090f5ba0be.PNG)

**Next** #6 
