### PR TITLE
Tutorial[8,9]: Helpers and Event Listeners

### DIFF
--- a/client/scripts/helpers.ts
+++ b/client/scripts/helpers.ts
@@ -1,7 +1,7 @@
 interface HelpersInterface {
   formatPrice(cents: number);
-  rando(arr: Array<String>);
-  slugify(text: String);
+  rando(arr: Array<string>);
+  slugify(text: string);
   getFunName();
 }
 
@@ -16,10 +16,10 @@ class helpers implements HelpersInterface {
   }
   /**
    * Takes an array and returns a random one
-   * @param {Array<String>} arr - array of strings
+   * @param {Array<string>} arr - array of strings
    * @returns {String} one element from the given array of strings
    */
-  rando(arr: Array<String>) {
+  rando(arr: Array<string>) {
     return arr[Math.floor(Math.random() * arr.length)];
   }
 
@@ -28,7 +28,7 @@ class helpers implements HelpersInterface {
    * @param {String} text - text to become simpler
    * @returns {string} slug form of string
    */
-  slugify(text: String) {
+  slugify(text: string) {
     return text.toString().toLowerCase()
       .replace(/\s+/g, '-')           // Replace spaces with -
       .replace(/[^\w\-]+/g, '')       // Remove all non-word chars

--- a/client/scripts/helpers.ts
+++ b/client/scripts/helpers.ts
@@ -1,23 +1,51 @@
-let helpers =  {
-  formatPrice :  function(cents) {
+interface HelpersInterface {
+  formatPrice(cents: number);
+  rando(arr: Array<String>);
+  slugify(text: String);
+  getFunName();
+}
+
+class helpers implements HelpersInterface {
+  /**
+   * Takes cents and returns dollar
+   * @param {Number} cents - cents value as a number
+   * @returns {String} string of dollars based on cents
+   */
+  formatPrice(cents: number) {
     return '$' + ( (cents / 100).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",") );
-  },
-  rando : function(arr) {
+  }
+  /**
+   * Takes an array and returns a random one
+   * @param {Array<String>} arr - array of strings
+   * @returns {String} one element from the given array of strings
+   */
+  rando(arr: Array<String>) {
     return arr[Math.floor(Math.random() * arr.length)];
-  },
-  slugify : function(text) {
+  }
+
+  /**
+   * Takes a string and removes human readable bits
+   * @param {String} text - text to become simpler
+   * @returns {string} slug form of string
+   */
+  slugify(text: String) {
     return text.toString().toLowerCase()
       .replace(/\s+/g, '-')           // Replace spaces with -
       .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
       .replace(/\-\-+/g, '-')         // Replace multiple - with single -
       .replace(/^-+/, '')             // Trim - from start of text
       .replace(/-+$/, '');            // Trim - from end of text
-  },
-  getFunName : function() {
+  }
+
+  /**
+   * Uses a library of words to return a 3 word combo
+   * @returns {String} A string containing 3 random words
+   */
+  getFunName() {
     var adjectives = ['adorable', 'beautiful', 'clean', 'drab', 'elegant', 'fancy', 'glamorous', 'handsome', 'long', 'magnificent', 'old-fashioned', 'plain', 'quaint', 'sparkling', 'ugliest', 'unsightly', 'angry', 'bewildered', 'clumsy', 'defeated', 'embarrassed', 'fierce', 'grumpy', 'helpless', 'itchy', 'jealous', 'lazy', 'mysterious', 'nervous', 'obnoxious', 'panicky', 'repulsive', 'scary', 'thoughtless', 'uptight', 'worried'];
-    
+
     var nouns = ['women', 'men', 'children', 'teeth', 'feet', 'people', 'leaves', 'mice', 'geese', 'halves', 'knives', 'wives', 'lives', 'elves', 'loaves', 'potatoes', 'tomatoes', 'cacti', 'foci', 'fungi', 'nuclei', 'syllabuses', 'analyses', 'diagnoses', 'oases', 'theses', 'crises', 'phenomena', 'criteria', 'data'];
-    
+
     return `${this.rando(adjectives)}-${this.rando(adjectives)}-${this.rando(nouns)}`;
   }
 }

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { render } from 'react-dom';
+import { render, findDOMNode } from 'react-dom';
 import { createHistory } from 'history';
-import { Router, Route } from 'react-router';
+import { Router, Route, History } from 'react-router';
 
 import helpers from './helpers';
 let h = new helpers();
@@ -77,9 +77,14 @@ class Header extends React.Component<HeaderProps, any> {
  * Store Picker example
  */
 class StorePicker extends React.Component<any, any> {
+  goToStore(event: React.FormEvent) {
+    event.preventDefault();
+    let storeInput = findDOMNode<HTMLInputElement>(this.refs['storeId']);
+    this.props.history.replaceState(null, '/store/' + storeInput.value);
+  }
   render() {
     return (
-      <form className="store-selector">
+      <form className="store-selector" onSubmit={e => this.goToStore(e)}>
         <h2>Please Enter a Store</h2>
         <input type="text" ref="storeId" defaultValue={h.getFunName()} required />
         <input type="submit" />

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -3,7 +3,8 @@ import { render } from 'react-dom';
 import { createHistory } from 'history';
 import { Router, Route } from 'react-router';
 
-import h from './helpers';
+import helpers from './helpers';
+let h = new helpers();
 
 /**
  * Interfaces

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -3,6 +3,8 @@ import { render } from 'react-dom';
 import { createHistory } from 'history';
 import { Router, Route } from 'react-router';
 
+import h from './helpers';
+
 /**
  * Interfaces
  */
@@ -78,7 +80,7 @@ class StorePicker extends React.Component<any, any> {
     return (
       <form className="store-selector">
         <h2>Please Enter a Store</h2>
-        <input type="text" ref="storeId" required />
+        <input type="text" ref="storeId" defaultValue={h.getFunName()} required />
         <input type="submit" />
       </form>
     )


### PR DESCRIPTION
**Prev** #6 
- [x] use helpers to add fun name
  - [x] add typescript interface for helper.ts module
- [x] add functionality for picking a store id
  - [x] create goToStore and bind via arrow
  - [x] find store input via react dom `findDOMnode` :tada: 

Tutorial 8 and 9 really brought alot of typescript challenges but also some great learnings!

**[ 8 ]** Most of my time was spent in cleaning up the helpers.ts to be more typescripty in terms of having an interface and defined types for params. I also encountered a couple issues using String or Number for types instead of their simplier cousins number and string 5415ae3fb34a5c635e8a58e2fcdc8d564155c721.

**[ 9 ]** Alot of my time was spent figuring out how to bind `this` to goToStore and how to properly fetch the store input element. The binding was most interesting (I had at one point a constructor where I was binding this by doing `this.goToStore = this.goToStore.bind(this)` :lollipop: ) and I eventually settled on binding via the arrow function `e => this.goToStore(e)`. Both of the resources I used are listed below.
http://stackoverflow.com/a/29740405
http://stackoverflow.com/a/32915014

**[ Special Mixin Mention ]** There was one terrible rabbit hole I went down where I attempted to use mixins with my react components (you cannot do this outside the createClass and is not recommended for typescript or es6). Specifically it was around how to utilize the react router history, which was conveniently added as a higher order component in v1.0.0 [using es6 classes](https://github.com/rackt/react-router/blob/fe9358adc864c556afff6fd472476ab84ce2d7d9/docs/api/History.md#but-im-using-classes) meaning you can access alot of the old mixins via `this.props`.

**Next** #9 
