### PR TITLE
Tutorial[13,14]: Updating and Displaying the order state

### DIFF
--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -170,7 +170,7 @@ class AddFishForm extends React.Component<AddFishProps, any> {
  * Order Container
  */
 class Order extends React.Component<OrderProps, any> {
-  private renderOrder = ( orderIds: string[] ) => {
+  private renderOrders = ( orderIds: string[] ) => {
     return orderIds.map((key) => {
       let fish: FishObject = this.props.fishes[key];
       let count: number = this.props.order[key];
@@ -204,7 +204,7 @@ class Order extends React.Component<OrderProps, any> {
       <div className="order-wrap">
         <h2 className="order-title">Your Order</h2>
         <ul className="order">
-          {this.renderOrder(orderIds)}
+          {this.renderOrders(orderIds)}
           <li className="total">
             <strong>Total:</strong>
             {h.formatPrice(total)}

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -13,14 +13,6 @@ interface HeaderProps {
   tagline: string;
 }
 
-interface FishObject {
-  name: string;
-  price: number;
-  status: string;
-  desc: string;
-  image: string;
-}
-
 interface FishDataProps {
   key: number;
   index: number;
@@ -28,11 +20,29 @@ interface FishDataProps {
   addToOrder(key: number);
 }
 
+interface OrderProps {
+  fishes: Object;
+  order: Object;
+}
+
+interface InventoryProps {
+  addFish(fish: FishObject);
+  loadSamples();
+}
+
 interface AddFishProps {
   /**
    * takes an object of type Fish and saves it to the app state fishes
    */
   addFish(fish: FishObject);
+}
+
+interface FishObject {
+  name: string;
+  price: number;
+  status: string;
+  desc: string;
+  image: string;
 }
 
 /**
@@ -75,6 +85,14 @@ class App extends React.Component<any, any> {
   };
 
   render() {
+    let orderProps: OrderProps = {
+      fishes: this.state.fishes,
+      order: this.state.order
+    };
+    let inventoryProps: InventoryProps = {
+      addFish: this.addFish,
+      loadSamples: this.loadSamples
+    };
     return (
       <div className="catch-of-the-day">
         <div className="menu">
@@ -83,8 +101,8 @@ class App extends React.Component<any, any> {
             {Object.keys(this.state.fishes).map(this.renderFish)}
           </ul>
         </div>
-        <Order />
-        <Inventory addFish={this.addFish} loadSamples={this.loadSamples}/>
+        <Order {...orderProps}/>
+        <Inventory {...inventoryProps}/>
       </div>
     );
   }

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -22,9 +22,10 @@ interface FishObject {
 }
 
 interface FishDataProps {
-  key: number;
-  index: number;
+  key: string;
+  index: string;
   details: FishObject;
+  addToOrder(key: string);
 }
 
 interface AddFishProps {
@@ -58,13 +59,19 @@ class App extends React.Component<any, any> {
     });
   };
 
-  public renderFish = (key) => {
+  public renderFish = (key: string) => {
     let fishData: FishDataProps = {
       key: key,
       index: key,
-      details: this.state.fishes[key]
+      details: this.state.fishes[key],
+      addToOrder: this.addToOrder
     };
     return <Fish {...fishData}/>;
+  };
+
+  public addToOrder = (key: string) => {
+    this.state.order[key] = this.state.order[key] + 1 || 1;
+    this.setState({ order: this.state.order });
   };
 
   render() {

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -169,10 +169,48 @@ class AddFishForm extends React.Component<AddFishProps, any> {
 /**
  * Order Container
  */
-class Order extends React.Component<any, any> {
+class Order extends React.Component<OrderProps, any> {
+  private renderOrder = ( orderIds: string[] ) => {
+    return orderIds.map((key) => {
+      let fish: FishObject = this.props.fishes[key];
+      let count: number = this.props.order[key];
+
+      if(!fish) {
+        return <li key={key}>Sorry, fish no longer available!</li>;
+      }
+      return (
+        <li key={key}>
+          <span>{count}lbs</span>
+          <span>{fish.name}</span>
+          <span className="price">{h.formatPrice(count * fish.price)}</span>
+        </li>
+      );
+    });
+  };
   render() {
+    let orderIds = Object.keys(this.props.order);
+    let total = orderIds.reduce((prevTotal, key) => {
+      let fish: FishObject = this.props.fishes[key];
+      let count: number = this.props.order[key];
+      let isAvailable = fish && fish.status === "available";
+
+      if(fish && isAvailable) {
+        return prevTotal + (count * fish.price || 0);
+      }
+      return prevTotal;
+    }, 0);
+
     return (
-      <p>Order</p>
+      <div className="order-wrap">
+        <h2 className="order-title">Your Order</h2>
+        <ul className="order">
+          {this.renderOrder(orderIds)}
+          <li className="total">
+            <strong>Total:</strong>
+            {h.formatPrice(total)}
+          </li>
+        </ul>
+      </div>
     );
   }
 }

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -22,10 +22,10 @@ interface FishObject {
 }
 
 interface FishDataProps {
-  key: string;
-  index: string;
+  key: number;
+  index: number;
   details: FishObject;
-  addToOrder(key: string);
+  addToOrder(key: number);
 }
 
 interface AddFishProps {
@@ -59,7 +59,7 @@ class App extends React.Component<any, any> {
     });
   };
 
-  public renderFish = (key: string) => {
+  public renderFish = (key: any) => {
     let fishData: FishDataProps = {
       key: key,
       index: key,
@@ -69,7 +69,7 @@ class App extends React.Component<any, any> {
     return <Fish {...fishData}/>;
   };
 
-  public addToOrder = (key: string) => {
+  public addToOrder = (key: number) => {
     this.state.order[key] = this.state.order[key] + 1 || 1;
     this.setState({ order: this.state.order });
   };

--- a/client/scripts/main.tsx
+++ b/client/scripts/main.tsx
@@ -87,8 +87,13 @@ class App extends React.Component<any, any> {
  * Fish component
  */
 class Fish extends React.Component<FishDataProps, any> {
+  private onButtonClick = () => {
+    this.props.addToOrder(this.props.index);
+  };
   render() {
     let details = this.props.details;
+    let isAvailable: boolean = (details.status === "available" ? true : false);
+    let buttonText: string = (isAvailable ? "Add to Order" : "Sold Out!");
     return (
       <li className="menu-fish">
         <img src={details.image} alt={details.name} />
@@ -97,6 +102,7 @@ class Fish extends React.Component<FishDataProps, any> {
           <span className="price">{h.formatPrice(details.price)}</span>
         </h3>
         <p>{details.desc}</p>
+        <button disabled={!isAvailable} onClick={this.onButtonClick}>{buttonText}</button>
       </li>
     );
   }


### PR DESCRIPTION
**Prev** #10 

**Tutorial 13**
- Made good use of the existing `FishDataProps` by adding the new `addToOrder` to its contract.
- Utilized private for the `onButtonClick` (no need for other areas of the app to interact with this)
- `addToOrder` is public and can be accessed in other areas of the app (you can imagine wanting to add to the order from many different areas)

**Tutorial 14**
- Added two new interfaces to represent the shape that the props should take when initializing Order and Inventory.
- Used the new order prop to catch naming mistakes while coding
  ![tut1314_1](https://cloud.githubusercontent.com/assets/1335972/11988664/43c162fa-a9a8-11e5-9e9c-6d8daa577d08.PNG)
- Enforcement of price being a number, on the fish object, removed the need for `parseInt` here
- created `renderOrders` to produce all the jsx elements for orders rather then one at a time.

**Next** #12 
