### PR TITLE
Cleanup stateless components

### DIFF
--- a/scripts/components/AddFishButton.tsx
+++ b/scripts/components/AddFishButton.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-import { AddButtonProps } from "../libs/interfaces";
+import React = require("react");
 
-export const AddFishButton: React.StatelessComponent<AddButtonProps> = ({text, isAvailable, addToOrder}) => (
+export const AddFishButton = ({text = "default", isAvailable = true, addToOrder}) => (
   <button disabled={!isAvailable} onClick={addToOrder}>{text}</button>
 );

--- a/scripts/components/Fish.tsx
+++ b/scripts/components/Fish.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { AddFishButton } from "./AddFishButton";
 import { PriceLabel } from "./PriceLabel";
-import { FishDataProps, AddButtonProps, PriceLabelProps } from "../libs/interfaces";
+import { FishDataProps } from "../libs/interfaces";
 
 /**
  * Fish component
@@ -15,14 +15,10 @@ export class Fish extends React.Component<FishDataProps, any> {
     let isAvailable: boolean = (details.status === "available" ? true : false);
     let buttonText: string = (isAvailable ? "Add to Order" : "Sold Out!");
 
-    let AddProps: AddButtonProps = {
+    let AddProps = {
       text: buttonText,
       isAvailable: isAvailable,
       addToOrder: this.onButtonClick
-    };
-
-    let PriceProps: PriceLabelProps = {
-      price: details.price
     };
 
     return (
@@ -30,7 +26,7 @@ export class Fish extends React.Component<FishDataProps, any> {
         <img src={details.image} alt={details.name} />
         <h3 className="fish-name">
           {details.name}
-          <PriceLabel {...PriceProps} />
+          <PriceLabel price={details.price} />
         </h3>
         <p>{details.desc}</p>
         <AddFishButton {...AddProps} />

--- a/scripts/components/FishOrder.tsx
+++ b/scripts/components/FishOrder.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as CSSTransitionGroup from "react-addons-css-transition-group";
 import { PriceLabel } from "./PriceLabel";
-import { FishOrderProps, PriceLabelProps } from "../libs/interfaces";
+import { FishOrderProps } from "../libs/interfaces";
 
 export class FishOrder extends React.Component<FishOrderProps, any> {
   private removeFromOrder = () => {
@@ -20,10 +20,6 @@ export class FishOrder extends React.Component<FishOrderProps, any> {
       transitionLeaveTimeout: 250
     };
 
-    let PriceProps: PriceLabelProps = {
-      price: (count * fish.price)
-    };
-
     if(!fish) {
       return <li key={this.props.index}>Sorry, fish no longer available! {removeButton}</li>;
     }
@@ -33,7 +29,7 @@ export class FishOrder extends React.Component<FishOrderProps, any> {
           <span key={count}>{count}</span>
         </CSSTransitionGroup>
         lbs {fish.name} {removeButton}
-        <PriceLabel {...PriceProps} />
+        <PriceLabel price={count * fish.price} />
       </li>
     );
   }

--- a/scripts/components/Order.tsx
+++ b/scripts/components/Order.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as CSSTransitionGroup from "react-addons-css-transition-group";
-import { FishData, OrderProps, FishOrderProps, PriceLabelProps } from "../libs/interfaces";
+import { FishData, OrderProps, FishOrderProps } from "../libs/interfaces";
 
 import { FishOrder } from "./FishOrder";
 import { PriceLabel } from "./PriceLabel";
@@ -46,10 +46,6 @@ export class Order extends React.Component<OrderProps, any> {
       className: "order"
     };
 
-    let PriceProps: PriceLabelProps = {
-      price: total
-    };
-
     return (
       <div className="order-wrap">
         <h2 className="order-title">Your Order</h2>
@@ -57,7 +53,7 @@ export class Order extends React.Component<OrderProps, any> {
           {this.renderOrders(orderIds)}
           <li className="total">
             <strong>Total:</strong>
-            <PriceLabel {...PriceProps}/>
+            <PriceLabel price={total}/>
           </li>
         </CSSTransitionGroup>
       </div>

--- a/scripts/components/PriceLabel.tsx
+++ b/scripts/components/PriceLabel.tsx
@@ -1,9 +1,7 @@
-import * as React from "react";
-import { PriceLabelProps } from "../libs/interfaces";
-
+import React = require("react");
 import helpers from "../libs/helpers";
 let h = new helpers();
 
-export const PriceLabel: React.StatelessComponent<PriceLabelProps> = ({price}) => (
+export const PriceLabel = ({price = 0}) => (
   <span className="price">{h.formatPrice(price)}</span>
 );

--- a/scripts/components/__tests__/AddFishButton-test.tsx
+++ b/scripts/components/__tests__/AddFishButton-test.tsx
@@ -1,11 +1,8 @@
 jest.dontMock("../AddFishButton");
-jest.dontMock("../../libs/interfaces");
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-addons-test-utils";
-
-import {AddButtonProps} from "../../libs/interfaces";
 
 import {AddFishButton} from "../AddFishButton";
 
@@ -13,8 +10,8 @@ describe("AddFishButton", () => {
 
   it("Renders", () => {
 
-    let addFishProps: AddButtonProps = {
-      text: "What does here",
+    let addFishProps = {
+      text: "What goes here",
       isAvailable: false,
       addToOrder: function(){return;}
     };
@@ -23,7 +20,8 @@ describe("AddFishButton", () => {
       <div><AddFishButton {...addFishProps}/></div>
     );
 
-    expect(ReactDOM.findDOMNode(AddFishStateless).textContent).toBe("What does here");
+    expect(ReactDOM.findDOMNode(AddFishStateless).textContent).toBe("What goes here");
+    expect(ReactDOM.findDOMNode(AddFishStateless).innerHTML).toContain("disabled");
   });
 
 });

--- a/scripts/components/__tests__/PriceLabel-test.tsx
+++ b/scripts/components/__tests__/PriceLabel-test.tsx
@@ -1,25 +1,18 @@
 jest.dontMock("../PriceLabel");
-jest.dontMock("../../libs/interfaces");
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-addons-test-utils";
-
-import {PriceLabelProps} from "../../libs/interfaces";
 
 import {PriceLabel} from "../PriceLabel";
 
 describe("PriceLabel", () => {
 
   it("Renders", () => {
-    let priceProps: PriceLabelProps = {
-      price: 12
-    };
-
     let PriceLabelStateless = TestUtils.renderIntoDocument(
-      <div><PriceLabel {...priceProps} /></div>
+      <div><PriceLabel price={120} /></div>
     );
-    expect(ReactDOM.findDOMNode(PriceLabelStateless).textContent).toBe("$0.12");
+    expect(TestUtils.isDOMComponent(PriceLabelStateless)).toBeTruthy();
   });
 
 });

--- a/scripts/libs/interfaces.ts
+++ b/scripts/libs/interfaces.ts
@@ -11,10 +11,6 @@ export interface AddButtonProps {
   addToOrder();
 }
 
-export interface PriceLabelProps {
-  price: number;
-}
-
 export interface FishData {
   name: string;
   price: number;


### PR DESCRIPTION
- [x] reduce function definition noise
- [x] cleanup tests

using the stateless components properly lets you keep full type checking while having less definition bloat :smile: . Truly a pleasure to pull out this `PriceLabel` from the components.

![cool123](https://cloud.githubusercontent.com/assets/1335972/13726373/5edca968-e879-11e5-926c-c83295d6ff3f.PNG)

![woahwoah234](https://cloud.githubusercontent.com/assets/1335972/13726374/71af3042-e879-11e5-878b-b11496eed141.gif)

![woahwoah23](https://cloud.githubusercontent.com/assets/1335972/13726378/a581c31c-e879-11e5-923d-77a847746735.gif)
